### PR TITLE
feat(engine): add game and player state records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,6 +206,11 @@ PublishScripts/
 **/[Pp]ackages/*
 # except build/, which is used as an MSBuild target.
 !**/[Pp]ackages/build/
+# Allow top-level packages directory for source projects
+!packages/
+!packages/**
+packages/**/[Bb]in/
+packages/**/[Oo]bj/
 # Uncomment if necessary however generally it will be regenerated when needed
 #!**/[Pp]ackages/repositories.config
 # NuGet v3's project.json files produces more ignorable files

--- a/TASKS.md
+++ b/TASKS.md
@@ -2,6 +2,7 @@
 
 - [x] Repo scaffold
 - [ ] Engine foundation
+  - [x] GameState & PlayerState records
 - [ ] API
 - [ ] Frontend
 - [ ] Tests & CI

--- a/packages/engine/Engine.csproj
+++ b/packages/engine/Engine.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+  </PropertyGroup>
+
+</Project>

--- a/packages/engine/GameState.cs
+++ b/packages/engine/GameState.cs
@@ -1,0 +1,8 @@
+namespace Villainous.Engine;
+
+public sealed record GameState(
+    Guid MatchId,
+    IReadOnlyList<PlayerState> Players,
+    int CurrentPlayerIndex,
+    int Turn
+);

--- a/packages/engine/PlayerState.cs
+++ b/packages/engine/PlayerState.cs
@@ -1,0 +1,7 @@
+namespace Villainous.Engine;
+
+public sealed record PlayerState(
+    Guid Id,
+    string Villain,
+    int Power
+);

--- a/packages/model/Model.csproj
+++ b/packages/model/Model.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+  </PropertyGroup>
+
+</Project>

--- a/packages/model/Placeholder.cs
+++ b/packages/model/Placeholder.cs
@@ -1,0 +1,5 @@
+namespace Villainous.Model;
+
+public class Placeholder
+{
+}


### PR DESCRIPTION
## Summary
- allow tracking top-level packages directory
- add engine and model projects
- define immutable GameState and PlayerState records
- track progress in TASKS checklist

## Testing
- `dotnet format Villainous.sln --no-restore -v diag`
- `dotnet build Villainous.sln`


------
https://chatgpt.com/codex/tasks/task_e_68abfe152c5c832694dad6200ecdcc3f