### PR TITLE
feat: surface ProblemDetails codes and redact game state

### DIFF
--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -94,6 +94,7 @@ Request:
 {
   "type": "Fate",
   "playerId": "11111111-1111-1111-1111-111111111111",
+  "clientSeq": 1,
   "targetPlayerId": "22222222-2222-2222-2222-222222222222",
   "card": "ariel"
 }
@@ -107,6 +108,11 @@ Response `200 OK`:
 Error `400 Bad Request` for unknown command types:
 ```json
 { "title": "Unknown command type", "status": 400, "type": "rules.illegal_action" }
+```
+
+Error `409 Conflict` for duplicate `clientSeq` submissions:
+```json
+{ "title": "Duplicate command", "status": 409, "type": "command.duplicate" }
 ```
 
 ---

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
     <PackageVersion Include="Serilog.AspNetCore" Version="9.0.0" />
+    <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageVersion Include="Serilog.Sinks.Seq" Version="8.0.0" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/TASKS.md
+++ b/TASKS.md
@@ -47,10 +47,10 @@
 - [x] ✅ Emit `CommandRejected` with `code` and `traceId` on SignalR errors
   _Rationale_: mirror REST error shape
   _Acceptance Criteria_: hub sends structured rejection messages.
-- [ ] ⛔ Redact hidden information from GameState DTOs
+- [x] ✅ Redact hidden information from GameState DTOs
   _Rationale_: prevent opponent info leaks
   _Acceptance Criteria_: opponent hand and fate deck counts only.
-- [ ] ⛔ Support idempotent commands via `{matchId, playerId, clientSeq}`
+- [x] ✅ Support idempotent commands via `{matchId, playerId, clientSeq}`
   _Rationale_: avoid duplicate effects
   _Acceptance Criteria_: duplicate submissions are ignored or rejected.
 - [x] ✅ Provide `/healthz/live` and `/ready` endpoints
@@ -64,10 +64,10 @@
 - [x] ✅ Build core UI (realms, action spots, hand view, prompt modals)
   _Rationale_: allow players to take actions
   _Acceptance Criteria_: components render and respond to state.
-- [ ] 🕓 Handle REST/SignalR errors with ProblemDetails and traceId display
+- [x] ✅ Handle REST/SignalR errors with ProblemDetails and traceId display
   _Rationale_: help users report issues
   _Acceptance Criteria_: error boundary shows title, code, and traceId.
-- [ ] ⛔ Add accessibility basics (focus traps, ARIA roles, keyboard nav)
+- [x] ✅ Add accessibility basics (focus traps, ARIA roles, keyboard nav)
   _Rationale_: usable by keyboard‑only players
   _Acceptance Criteria_: prompts trap focus and provide ARIA labels.
 - [ ] ⛔ Implement SignalR reconnect logic on transient network loss
@@ -75,16 +75,16 @@
   _Acceptance Criteria_: client retries and rejoins matches automatically.
 
 ## Observability
-- [ ] 🕓 Configure Serilog with console, file, and Seq sinks
+- [x] ✅ Configure Serilog with console, file, and Seq sinks
   _Rationale_: collect structured logs
   _Acceptance Criteria_: appsettings configure all sinks.
-- [ ] 🕓 Enable OpenTelemetry tracing and metrics exporters
+- [x] ✅ Enable OpenTelemetry tracing and metrics exporters
   _Rationale_: support tracing backends
   _Acceptance Criteria_: OTEL configured with Otlp exporter.
-- [ ] ⛔ Propagate `traceId` into logs and ProblemDetails
+- [x] ✅ Propagate `traceId` into logs and ProblemDetails
   _Rationale_: correlate errors with traces
   _Acceptance Criteria_: `traceId` present in log context and error payloads.
-- [ ] ⛔ Enrich logs with `matchId` and `playerId`, omitting hidden info
+- [x] ✅ Enrich logs with `matchId` and `playerId`, omitting hidden info
   _Rationale_: maintain observability without leaks
   _Acceptance Criteria_: structured logging tested for redaction.
 

--- a/apps/api.Tests/GetMatchStateTests.cs
+++ b/apps/api.Tests/GetMatchStateTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Net.Http.Json;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Testing;
-using Villainous.Engine;
 using Villainous.Model;
 using Xunit;
 
@@ -24,7 +23,7 @@ public class GetMatchStateTests : IClassFixture<WebApplicationFactory<Program>>
         var create = await client.PostAsJsonAsync("/api/matches", request);
         var match = await create.Content.ReadFromJsonAsync<CreateMatchResponse>();
 
-        var state = await client.GetFromJsonAsync<GameState>($"/api/matches/{match!.MatchId}/state");
+        var state = await client.GetFromJsonAsync<GameStateDto>($"/api/matches/{match!.MatchId}/state");
 
         Assert.NotNull(state);
         Assert.Equal(match!.MatchId, state!.MatchId);

--- a/apps/api.Tests/LoggingTests.cs
+++ b/apps/api.Tests/LoggingTests.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+using Villainous.Model;
+using Xunit;
+
+namespace Villainous.Api.Tests;
+
+public class LoggingTests : IClassFixture<LoggingWebApplicationFactory>
+{
+    private readonly LoggingWebApplicationFactory factory;
+
+    public LoggingTests(LoggingWebApplicationFactory factory)
+    {
+        this.factory = factory;
+    }
+
+    [Fact]
+    public async Task RequestLogIncludesMatchAndPlayer()
+    {
+        var client = factory.CreateClient();
+        var create = await client.PostAsJsonAsync("/api/matches", new CreateMatchRequest(["Prince John", "Captain Hook"]));
+        var match = await create.Content.ReadFromJsonAsync<CreateMatchResponse>();
+        var state = await client.GetFromJsonAsync<GameStateDto>($"/api/matches/{match!.MatchId}/state");
+        var player = state!.Players[0].Id;
+        var target = state.Players[1].Id;
+
+        var command = new SubmitCommandRequest("Fate", player, 1, target, null, null, "Ariel");
+        await client.PostAsJsonAsync($"/api/matches/{match.MatchId}/commands", command);
+
+        LogEvent? evt = null;
+        for (var i = 0; i < 10 && evt == null; i++)
+        {
+            evt = factory.Sink.Events.FirstOrDefault(e =>
+                e.Properties.ContainsKey("MatchId") && e.Properties.ContainsKey("PlayerId"));
+            if (evt == null)
+            {
+                await Task.Delay(50);
+            }
+        }
+
+        Assert.NotNull(evt);
+        Assert.Equal(match.MatchId.ToString(), ((ScalarValue)evt!.Properties["MatchId"]).Value?.ToString());
+        Assert.Equal(player.ToString(), ((ScalarValue)evt.Properties["PlayerId"]).Value?.ToString());
+        Assert.All(evt.Properties.Values, v => Assert.DoesNotContain("Ariel", v.ToString()));
+    }
+}
+
+public class LoggingWebApplicationFactory : WebApplicationFactory<Program>
+{
+    public InMemorySink Sink { get; } = new();
+
+    protected override IHost CreateHost(IHostBuilder builder)
+    {
+        Log.Logger = new LoggerConfiguration()
+            .Enrich.FromLogContext()
+            .WriteTo.Sink(Sink)
+            .CreateLogger();
+        builder.UseSerilog();
+        return base.CreateHost(builder);
+    }
+}
+
+public class InMemorySink : ILogEventSink
+{
+    public System.Collections.Concurrent.ConcurrentBag<LogEvent> Events { get; } = new();
+    public void Emit(LogEvent logEvent) => Events.Add(logEvent);
+}

--- a/apps/api.Tests/NonParallel.cs
+++ b/apps/api.Tests/NonParallel.cs
@@ -1,0 +1,2 @@
+using Xunit;
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/apps/api.Tests/PostMatchCommandsTests.cs
+++ b/apps/api.Tests/PostMatchCommandsTests.cs
@@ -4,7 +4,6 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Testing;
-using Villainous.Engine;
 using Villainous.Model;
 using Xunit;
 
@@ -24,11 +23,11 @@ public class PostMatchCommandsTests : IClassFixture<WebApplicationFactory<Progra
     {
         var create = await client.PostAsJsonAsync("/api/matches", new CreateMatchRequest(["Prince John", "Captain Hook"]));
         var match = await create.Content.ReadFromJsonAsync<CreateMatchResponse>();
-        var state = await client.GetFromJsonAsync<GameState>($"/api/matches/{match!.MatchId}/state");
+        var state = await client.GetFromJsonAsync<GameStateDto>($"/api/matches/{match!.MatchId}/state");
         var player = state!.Players[0].Id;
         var target = state.Players[1].Id;
 
-        var command = new SubmitCommandRequest("Fate", player, target, null, null, "Ariel");
+        var command = new SubmitCommandRequest("Fate", player, 1, target, null, null, "Ariel");
         var response = await client.PostAsJsonAsync($"/api/matches/{match!.MatchId}/commands", command);
         response.EnsureSuccessStatusCode();
 
@@ -39,7 +38,7 @@ public class PostMatchCommandsTests : IClassFixture<WebApplicationFactory<Progra
     [Fact]
     public async Task Returns404ForUnknownId()
     {
-        var command = new SubmitCommandRequest("CheckObjective", Guid.NewGuid(), null, null, null, null);
+        var command = new SubmitCommandRequest("CheckObjective", Guid.NewGuid(), 1, null, null, null, null);
         var response = await client.PostAsJsonAsync($"/api/matches/{Guid.NewGuid()}/commands", command);
         var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
@@ -53,12 +52,31 @@ public class PostMatchCommandsTests : IClassFixture<WebApplicationFactory<Progra
     {
         var create = await client.PostAsJsonAsync("/api/matches", new CreateMatchRequest(["Prince John", "Captain Hook"]));
         var match = await create.Content.ReadFromJsonAsync<CreateMatchResponse>();
-        var command = new SubmitCommandRequest("Unknown", Guid.NewGuid(), null, null, null, null);
+        var command = new SubmitCommandRequest("Unknown", Guid.NewGuid(), 1, null, null, null, null);
         var response = await client.PostAsJsonAsync($"/api/matches/{match!.MatchId}/commands", command);
         var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         Assert.Equal("Unknown command type", problem!.Title);
         Assert.Equal("command.unknown_type", problem.Extensions["code"]?.ToString());
+        Assert.False(string.IsNullOrEmpty(problem.Extensions["traceId"]?.ToString()));
+    }
+
+    [Fact]
+    public async Task Returns409ForDuplicateClientSeq()
+    {
+        var create = await client.PostAsJsonAsync("/api/matches", new CreateMatchRequest(["Prince John", "Captain Hook"]));
+        var match = await create.Content.ReadFromJsonAsync<CreateMatchResponse>();
+        var state = await client.GetFromJsonAsync<GameStateDto>($"/api/matches/{match!.MatchId}/state");
+        var player = state!.Players[0].Id;
+        var target = state.Players[1].Id;
+
+        var command = new SubmitCommandRequest("Fate", player, 1, target, null, null, "Ariel");
+        await client.PostAsJsonAsync($"/api/matches/{match.MatchId}/commands", command);
+
+        var second = await client.PostAsJsonAsync($"/api/matches/{match.MatchId}/commands", command);
+        var problem = await second.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.Equal(HttpStatusCode.Conflict, second.StatusCode);
+        Assert.Equal("command.duplicate", problem!.Extensions["code"]?.ToString());
         Assert.False(string.IsNullOrEmpty(problem.Extensions["traceId"]?.ToString()));
     }
 }

--- a/apps/api.Tests/ProblemFactoryTests.cs
+++ b/apps/api.Tests/ProblemFactoryTests.cs
@@ -1,0 +1,21 @@
+using System.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Villainous.Api.Tests;
+
+public class ProblemFactoryTests
+{
+    [Fact]
+    public void UsesActivityTraceId()
+    {
+        var context = new DefaultHttpContext();
+        using var activity = new Activity("test").Start();
+
+        var problem = ProblemFactory.CreateDetails(context, StatusCodes.Status500InternalServerError, "err", "Error");
+
+        Assert.Equal(activity.TraceId.ToString(), problem.Extensions["traceId"]?.ToString());
+    }
+}
+

--- a/apps/api/Api.csproj
+++ b/apps/api/Api.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
     <PackageReference Include="Serilog.AspNetCore" />
+    <PackageReference Include="Serilog.Sinks.File" />
     <PackageReference Include="Serilog.Sinks.Seq" />
   </ItemGroup>
 

--- a/apps/api/GameStateExtensions.cs
+++ b/apps/api/GameStateExtensions.cs
@@ -1,0 +1,22 @@
+using System.Linq;
+using Villainous.Engine;
+using Villainous.Model;
+
+namespace Villainous.Api;
+
+public static class GameStateExtensions
+{
+    public static GameStateDto ToDto(this GameState state) => new(
+        state.MatchId,
+        state.Players.Select(p => new PlayerStateDto(
+            p.Id,
+            p.Villain,
+            p.Power,
+            p.Locations,
+            p.VillainDeckCount,
+            p.FateDeckCount
+        )).ToList(),
+        state.CurrentPlayerIndex,
+        state.Turn
+    );
+}

--- a/apps/api/ProblemFactory.cs
+++ b/apps/api/ProblemFactory.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
@@ -13,7 +14,7 @@ public static class ProblemFactory
             Status = statusCode
         };
         problem.Extensions["code"] = code;
-        problem.Extensions["traceId"] = context.TraceIdentifier;
+        problem.Extensions["traceId"] = Activity.Current?.TraceId.ToString() ?? context.TraceIdentifier;
         return problem;
     }
 

--- a/apps/api/Program.cs
+++ b/apps/api/Program.cs
@@ -1,20 +1,29 @@
 using System;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 using Serilog;
+using Serilog.Context;
 using Villainous.Engine;
 using Villainous.Model;
 using Villainous.Api;
 
 var builder = WebApplication.CreateBuilder(args);
-builder.Host.UseSerilog((ctx, services, cfg) => cfg
-    .ReadFrom.Configuration(ctx.Configuration)
-    .ReadFrom.Services(services)
-    .Enrich.FromLogContext());
+builder.Host.UseSerilog((ctx, services, cfg) =>
+{
+    cfg.ReadFrom.Configuration(ctx.Configuration)
+       .ReadFrom.Services(services)
+       .Enrich.FromLogContext();
+    var sink = services.GetService<Serilog.Core.ILogEventSink>();
+    if (sink is not null)
+    {
+        cfg.WriteTo.Sink(sink);
+    }
+});
 
 builder.Services.AddHealthChecks();
 
@@ -31,13 +40,24 @@ builder.Services.AddOpenTelemetry()
 
 builder.Services.AddSingleton<ConcurrentDictionary<Guid, GameState>>();
 builder.Services.AddSingleton<ConcurrentDictionary<Guid, List<DomainEvent>>>();
+builder.Services.AddSingleton<ConcurrentDictionary<(Guid, Guid, int), bool>>();
 builder.Services.AddSignalR();
 
 var app = builder.Build();
 app.UseSerilogRequestLogging();
 
+app.Use(async (ctx, next) =>
+{
+    var traceId = Activity.Current?.TraceId.ToString() ?? ctx.TraceIdentifier;
+    using (LogContext.PushProperty("TraceId", traceId))
+    {
+        await next();
+    }
+});
+
 var matches = app.Services.GetRequiredService<ConcurrentDictionary<Guid, GameState>>();
 var replays = app.Services.GetRequiredService<ConcurrentDictionary<Guid, List<DomainEvent>>>();
+var processed = app.Services.GetRequiredService<ConcurrentDictionary<(Guid, Guid, int), bool>>();
 
 app.MapHealthChecks("/healthz/live");
 app.MapHealthChecks("/ready");
@@ -55,17 +75,26 @@ app.MapPost("/api/matches", (CreateMatchRequest request) =>
 });
 
 app.MapGet("/api/matches/{id:guid}/state", (HttpContext ctx, Guid id) =>
-    matches.TryGetValue(id, out var state)
-        ? Results.Json(state)
-        : ProblemFactory.Create(ctx, StatusCodes.Status404NotFound, "match.not_found", "Match not found"));
+{
+    using var _ = LogContext.PushProperty("MatchId", id);
+    return matches.TryGetValue(id, out var state)
+        ? Results.Json(state.ToDto())
+        : ProblemFactory.Create(ctx, StatusCodes.Status404NotFound, "match.not_found", "Match not found");
+});
 
 app.MapGet("/api/matches/{id:guid}/replay", (HttpContext ctx, Guid id) =>
-    replays.TryGetValue(id, out var events)
-        ? Results.Json(events)
-        : ProblemFactory.Create(ctx, StatusCodes.Status404NotFound, "match.not_found", "Match not found"));
-
-app.MapPost("/api/matches/{id:guid}/commands", (HttpContext ctx, Guid id, SubmitCommandRequest request) =>
 {
+    using var _ = LogContext.PushProperty("MatchId", id);
+    return replays.TryGetValue(id, out var events)
+        ? Results.Json(events)
+        : ProblemFactory.Create(ctx, StatusCodes.Status404NotFound, "match.not_found", "Match not found");
+});
+
+app.MapPost("/api/matches/{id:guid}/commands", (HttpContext ctx, Serilog.IDiagnosticContext diag, Guid id, SubmitCommandRequest request) =>
+{
+    diag.Set("MatchId", id);
+    diag.Set("PlayerId", request.PlayerId);
+
     if (!matches.TryGetValue(id, out var state))
     {
         return ProblemFactory.Create(ctx, StatusCodes.Status404NotFound, "match.not_found", "Match not found");
@@ -86,9 +115,18 @@ app.MapPost("/api/matches/{id:guid}/commands", (HttpContext ctx, Guid id, Submit
         return ProblemFactory.Create(ctx, StatusCodes.Status400BadRequest, "command.unknown_type", "Unknown command type");
     }
 
+    var key = (id, request.PlayerId, request.ClientSeq);
+    if (!processed.TryAdd(key, true))
+    {
+        return ProblemFactory.Create(ctx, StatusCodes.Status409Conflict, "command.duplicate", "Duplicate command");
+    }
+
     var (newState, events) = GameReducer.Reduce(state, command);
     matches[id] = newState;
     replays[id].AddRange(events);
+    Log.ForContext("MatchId", id)
+       .ForContext("PlayerId", request.PlayerId)
+       .Information("Command processed");
     return Results.Json(new SubmitCommandResponse(true));
 });
 

--- a/apps/api/appsettings.Development.json
+++ b/apps/api/appsettings.Development.json
@@ -3,6 +3,7 @@
     "MinimumLevel": "Debug",
     "WriteTo": [
       { "Name": "Console" },
+      { "Name": "File", "Args": { "path": "logs/api-.log", "rollingInterval": "Day" } },
       { "Name": "Seq", "Args": { "serverUrl": "http://localhost:5341" } }
     ]
   }

--- a/apps/web/src/api/problem-details.ts
+++ b/apps/web/src/api/problem-details.ts
@@ -6,6 +6,7 @@ export const problemDetailsSchema = z.object({
   status: z.number().optional(),
   detail: z.string().optional(),
   instance: z.string().optional(),
+  code: z.string().optional(),
   traceId: z.string().optional(),
 });
 

--- a/apps/web/src/api/signalr.ts
+++ b/apps/web/src/api/signalr.ts
@@ -1,5 +1,23 @@
 import { HubConnection, HubConnectionBuilder } from '@microsoft/signalr';
+import { problemDetailsSchema } from './problem-details';
+import { usePromptsStore } from '../stores/prompts.store';
 
 export function createHubConnection(url: string): HubConnection {
-  return new HubConnectionBuilder().withUrl(url).withAutomaticReconnect().build();
+  const connection = new HubConnectionBuilder()
+    .withUrl(url)
+    .withAutomaticReconnect()
+    .build();
+
+  connection.on('CommandRejected', (problem: unknown) => {
+    const details = problemDetailsSchema.parse(problem);
+    const parts = [details.title ?? 'Command rejected'];
+    if (details.code) parts.push(`[${details.code}]`);
+    if (details.traceId) parts.push(`(Trace ID: ${details.traceId})`);
+    const message = parts.join(' ');
+    usePromptsStore
+      .getState()
+      .showPrompt({ id: details.traceId ?? crypto.randomUUID(), message });
+  });
+
+  return connection;
 }

--- a/apps/web/src/components/error-boundary.tsx
+++ b/apps/web/src/components/error-boundary.tsx
@@ -23,6 +23,7 @@ export class ErrorBoundary extends Component<Props, State> {
       return (
         <div role="alert" className="bg-red-100 text-red-800 p-4">
           <p>{problem?.title ?? error.message}</p>
+          {problem?.code && <p className="text-xs">Code: {problem.code}</p>}
           {problem?.traceId && (
             <p className="text-xs">Trace ID: {problem.traceId}</p>
           )}

--- a/apps/web/src/features/prompt/prompt-modal.test.tsx
+++ b/apps/web/src/features/prompt/prompt-modal.test.tsx
@@ -12,9 +12,16 @@ describe('PromptModal', () => {
     usePromptsStore.getState().showPrompt({ id: '1', message: 'Hello there' });
     render(<PromptModal />);
 
-    expect(screen.getByRole('dialog')).toHaveTextContent('Hello there');
+    const dialog = screen.getByRole('dialog');
+    const button = screen.getByRole('button', { name: /close/i });
 
-    fireEvent.click(screen.getByRole('button', { name: /close/i }));
+    expect(dialog).toHaveTextContent('Hello there');
+    expect(button).toHaveFocus();
+
+    fireEvent.keyDown(dialog, { key: 'Tab' });
+    expect(button).toHaveFocus();
+
+    fireEvent.keyDown(dialog, { key: 'Escape' });
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/prompt/prompt-modal.tsx
+++ b/apps/web/src/features/prompt/prompt-modal.tsx
@@ -1,22 +1,47 @@
+import { useEffect, useRef } from 'react';
 import { usePromptsStore } from '../../stores/prompts.store';
 
 export function PromptModal() {
   const prompt = usePromptsStore((s) => s.prompt);
   const clear = usePromptsStore((s) => s.clearPrompt);
+  const closeRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (prompt) {
+      closeRef.current?.focus();
+    }
+  }, [prompt]);
 
   if (!prompt) return null;
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Escape') {
+      clear();
+    }
+
+    if (e.key === 'Tab') {
+      e.preventDefault();
+      closeRef.current?.focus();
+    }
+  };
 
   return (
     <div
       role="dialog"
       aria-modal="true"
+      aria-labelledby="prompt-message"
       className="fixed inset-0 flex items-center justify-center bg-black/50"
+      onKeyDown={handleKeyDown}
     >
       <div className="rounded bg-white p-4">
-        <p className="mb-4">{prompt.message}</p>
+        <p id="prompt-message" className="mb-4">
+          {prompt.message}
+        </p>
         <button
+          ref={closeRef}
           type="button"
           className="rounded border px-2 py-1"
+          aria-label="Close prompt"
           onClick={clear}
         >
           Close

--- a/packages/model/GameStateDto.cs
+++ b/packages/model/GameStateDto.cs
@@ -1,0 +1,8 @@
+namespace Villainous.Model;
+
+public sealed record GameStateDto(
+    Guid MatchId,
+    IReadOnlyList<PlayerStateDto> Players,
+    int CurrentPlayerIndex,
+    int Turn
+);

--- a/packages/model/Model.csproj
+++ b/packages/model/Model.csproj
@@ -13,4 +13,8 @@
     <None Include="../../LICENSE" Pack="true" PackagePath="" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="../engine/Engine.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/packages/model/PlayerStateDto.cs
+++ b/packages/model/PlayerStateDto.cs
@@ -1,0 +1,12 @@
+using Villainous.Engine;
+
+namespace Villainous.Model;
+
+public sealed record PlayerStateDto(
+    Guid Id,
+    string Villain,
+    int Power,
+    IReadOnlyList<LocationState> Locations,
+    int VillainDeckCount,
+    int FateDeckCount
+);

--- a/packages/model/SubmitCommandRequest.cs
+++ b/packages/model/SubmitCommandRequest.cs
@@ -5,6 +5,7 @@ using System;
 public record SubmitCommandRequest(
     string Type,
     Guid PlayerId,
+    int ClientSeq,
     Guid? TargetPlayerId,
     string? Location,
     string? Hero,


### PR DESCRIPTION
## Summary
- log API errors to rotating files during development
- show ProblemDetails code and trace IDs, including SignalR CommandRejected errors
- return GameStateDto that redacts hidden information
- reject duplicate commands by client sequence number
- propagate trace IDs to log context and ProblemDetails
- include matchId and playerId in log context and request logs to trace player actions
- ensure prompt modals trap focus and expose ARIA labels for keyboard accessibility

## Testing
- `dotnet test`
- `pnpm -C apps/web lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad639307a483269f37f2fd6cd41cd9