### PR TITLE
feat(api): restrict development CORS to allowlist

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -119,7 +119,7 @@
   _Acceptance Criteria_: guide reflects working defaults.
 
 ## Security
-- [ ] ⛔ Restrict CORS to allowlisted origins in development
+- [x] ✅ Restrict CORS to allowlisted origins in development
   _Rationale_: prevent unsolicited web access
   _Acceptance Criteria_: CORS policy configured with explicit origins.
 - [ ] ⛔ Add basic rate limiting to API and SignalR

--- a/apps/api/appsettings.Development.json
+++ b/apps/api/appsettings.Development.json
@@ -6,5 +6,8 @@
       { "Name": "File", "Args": { "path": "logs/api-.log", "rollingInterval": "Day" } },
       { "Name": "Seq", "Args": { "serverUrl": "http://localhost:5341" } }
     ]
+  },
+  "Cors": {
+    "AllowedOrigins": [ "http://localhost:5173" ]
   }
 }


### PR DESCRIPTION
## Summary
- limit development CORS to configured origins
- track CORS restriction task completion

## Testing
- `dotnet format` *(fails: The server disconnected unexpectedly)*
- `dotnet test`
- `pnpm -C apps/web test`


------
https://chatgpt.com/codex/tasks/task_e_68b2afd630dc8326acbcbd79012e99ff