### PR TITLE
feat(api): add rate limiting and request validation

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,6 +1,6 @@
 # TASKS
 
-## Test Status (2025-08-25)
+## Test Status (2025-08-30)
 - Backend line coverage: 86% (`dotnet test --collect:"XPlat Code Coverage"`)
 - Frontend line coverage: 91% (`pnpm -C apps/web test`)
 - Lint: passed (`pnpm -C apps/web lint`)
@@ -122,10 +122,10 @@
 - [x] ✅ Restrict CORS to allowlisted origins in development
   _Rationale_: prevent unsolicited web access
   _Acceptance Criteria_: CORS policy configured with explicit origins.
-- [ ] ⛔ Add basic rate limiting to API and SignalR
+ - [x] ✅ Add basic rate limiting to API and SignalR
   _Rationale_: mitigate abusive clients
   _Acceptance Criteria_: exceeding limits returns 429.
-- [ ] ⛔ Validate and sanitize all input DTOs
+ - [x] ✅ Validate and sanitize all input DTOs
   _Rationale_: defend against malformed data
   _Acceptance Criteria_: model binding rejects invalid payloads.
 

--- a/apps/api.Tests/CreateMatchTests.cs
+++ b/apps/api.Tests/CreateMatchTests.cs
@@ -6,11 +6,11 @@ using Xunit;
 
 namespace Villainous.Api.Tests;
 
-public class CreateMatchTests : IClassFixture<WebApplicationFactory<Program>>
+public class CreateMatchTests : IClassFixture<TestingWebApplicationFactory>
 {
     private readonly HttpClient client;
 
-    public CreateMatchTests(WebApplicationFactory<Program> factory)
+    public CreateMatchTests(TestingWebApplicationFactory factory)
     {
         client = factory.CreateClient();
     }

--- a/apps/api.Tests/GetMatchReplayTests.cs
+++ b/apps/api.Tests/GetMatchReplayTests.cs
@@ -9,11 +9,11 @@ using Xunit;
 
 namespace Villainous.Api.Tests;
 
-public class GetMatchReplayTests : IClassFixture<WebApplicationFactory<Program>>
+public class GetMatchReplayTests : IClassFixture<TestingWebApplicationFactory>
 {
     private readonly HttpClient client;
 
-    public GetMatchReplayTests(WebApplicationFactory<Program> factory)
+    public GetMatchReplayTests(TestingWebApplicationFactory factory)
     {
         client = factory.CreateClient();
     }

--- a/apps/api.Tests/GetMatchStateTests.cs
+++ b/apps/api.Tests/GetMatchStateTests.cs
@@ -7,11 +7,11 @@ using Xunit;
 
 namespace Villainous.Api.Tests;
 
-public class GetMatchStateTests : IClassFixture<WebApplicationFactory<Program>>
+public class GetMatchStateTests : IClassFixture<TestingWebApplicationFactory>
 {
     private readonly HttpClient client;
 
-    public GetMatchStateTests(WebApplicationFactory<Program> factory)
+    public GetMatchStateTests(TestingWebApplicationFactory factory)
     {
         client = factory.CreateClient();
     }

--- a/apps/api.Tests/HealthCheckTests.cs
+++ b/apps/api.Tests/HealthCheckTests.cs
@@ -5,11 +5,11 @@ using Xunit;
 
 namespace Villainous.Api.Tests;
 
-public class HealthCheckTests : IClassFixture<WebApplicationFactory<Program>>
+public class HealthCheckTests : IClassFixture<TestingWebApplicationFactory>
 {
     private readonly HttpClient client;
 
-    public HealthCheckTests(WebApplicationFactory<Program> factory)
+    public HealthCheckTests(TestingWebApplicationFactory factory)
     {
         client = factory.CreateClient();
     }

--- a/apps/api.Tests/InputValidationTests.cs
+++ b/apps/api.Tests/InputValidationTests.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Villainous.Model;
+using Xunit;
+
+namespace Villainous.Api.Tests;
+
+public class InputValidationTests : IClassFixture<TestingWebApplicationFactory>
+{
+    private readonly HttpClient client;
+
+    public InputValidationTests(TestingWebApplicationFactory factory)
+    {
+        client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task CreateMatchRejectsEmptyVillain()
+    {
+        var response = await client.PostAsJsonAsync("/api/matches", new CreateMatchRequest(["", "Captain Hook"]));
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("match.invalid_villains", problem!.Extensions["code"]?.ToString());
+    }
+
+    [Fact]
+    public async Task SubmitCommandTrimsStrings()
+    {
+        var create = await client.PostAsJsonAsync("/api/matches", new CreateMatchRequest(["Prince John", "Captain Hook"]));
+        var match = await create.Content.ReadFromJsonAsync<CreateMatchResponse>();
+        var state = await client.GetFromJsonAsync<GameStateDto>($"/api/matches/{match!.MatchId}/state");
+        var player = state!.Players[0].Id;
+
+        var command = new SubmitCommandRequest(" Vanquish ", player, 1, null, " Realm ", " Hero ", null);
+        var response = await client.PostAsJsonAsync($"/api/matches/{match.MatchId}/commands", command);
+        response.EnsureSuccessStatusCode();
+    }
+
+    [Fact]
+    public async Task SubmitCommandRejectsEmptyType()
+    {
+        var create = await client.PostAsJsonAsync("/api/matches", new CreateMatchRequest(["Prince John", "Captain Hook"]));
+        var match = await create.Content.ReadFromJsonAsync<CreateMatchResponse>();
+        var state = await client.GetFromJsonAsync<GameStateDto>($"/api/matches/{match!.MatchId}/state");
+        var player = state!.Players[0].Id;
+
+        var command = new SubmitCommandRequest("", player, 1, null, null, null, null);
+        var response = await client.PostAsJsonAsync($"/api/matches/{match.MatchId}/commands", command);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("command.invalid_type", problem!.Extensions["code"]?.ToString());
+    }
+}
+

--- a/apps/api.Tests/LoggingTests.cs
+++ b/apps/api.Tests/LoggingTests.cs
@@ -1,7 +1,6 @@
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Linq;
 using System.Net.Http.Json;
-using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Hosting;
 using Serilog;
 using Serilog.Core;
@@ -42,7 +41,7 @@ public class LoggingTests : IClassFixture<LoggingWebApplicationFactory>
     }
 }
 
-public class LoggingWebApplicationFactory : WebApplicationFactory<Program>
+public class LoggingWebApplicationFactory : TestingWebApplicationFactory
 {
     public InMemorySink Sink { get; } = new();
 
@@ -58,6 +57,6 @@ public class LoggingWebApplicationFactory : WebApplicationFactory<Program>
 
 public class InMemorySink : ILogEventSink
 {
-    public List<LogEvent> Events { get; } = new();
+    public ConcurrentBag<LogEvent> Events { get; } = new();
     public void Emit(LogEvent logEvent) => Events.Add(logEvent);
 }

--- a/apps/api.Tests/MatchHubTests.cs
+++ b/apps/api.Tests/MatchHubTests.cs
@@ -9,11 +9,11 @@ using Xunit;
 
 namespace Villainous.Api.Tests;
 
-public class MatchHubTests : IClassFixture<WebApplicationFactory<Program>>
+public class MatchHubTests : IClassFixture<TestingWebApplicationFactory>
 {
-    private readonly WebApplicationFactory<Program> factory;
+    private readonly TestingWebApplicationFactory factory;
 
-    public MatchHubTests(WebApplicationFactory<Program> factory)
+    public MatchHubTests(TestingWebApplicationFactory factory)
     {
         this.factory = factory;
     }

--- a/apps/api.Tests/PostMatchCommandsTests.cs
+++ b/apps/api.Tests/PostMatchCommandsTests.cs
@@ -9,11 +9,11 @@ using Xunit;
 
 namespace Villainous.Api.Tests;
 
-public class PostMatchCommandsTests : IClassFixture<WebApplicationFactory<Program>>
+public class PostMatchCommandsTests : IClassFixture<TestingWebApplicationFactory>
 {
     private readonly HttpClient client;
 
-    public PostMatchCommandsTests(WebApplicationFactory<Program> factory)
+    public PostMatchCommandsTests(TestingWebApplicationFactory factory)
     {
         client = factory.CreateClient();
     }

--- a/apps/api.Tests/RateLimitingTests.cs
+++ b/apps/api.Tests/RateLimitingTests.cs
@@ -1,0 +1,29 @@
+using System.Net;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Villainous.Api.Tests;
+
+public class RateLimitingTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly HttpClient client;
+
+    public RateLimitingTests(WebApplicationFactory<Program> factory)
+    {
+        client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task Returns429WhenLimitExceeded()
+    {
+        for (var i = 0; i < 5; i++)
+        {
+            var ok = await client.GetAsync("/ready");
+            Assert.True(ok.IsSuccessStatusCode);
+        }
+
+        var rejected = await client.GetAsync("/ready");
+        Assert.Equal(HttpStatusCode.TooManyRequests, rejected.StatusCode);
+    }
+}
+

--- a/apps/api.Tests/TestingWebApplicationFactory.cs
+++ b/apps/api.Tests/TestingWebApplicationFactory.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace Villainous.Api.Tests;
+
+public class TestingWebApplicationFactory : WebApplicationFactory<Program>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+    }
+}
+

--- a/packages/model/CreateMatchRequest.cs
+++ b/packages/model/CreateMatchRequest.cs
@@ -1,5 +1,6 @@
 namespace Villainous.Model;
 
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 
-public record CreateMatchRequest(IReadOnlyList<string> Villains);
+public record CreateMatchRequest([property: Required, MinLength(2)] IReadOnlyList<string> Villains);

--- a/packages/model/SubmitCommandRequest.cs
+++ b/packages/model/SubmitCommandRequest.cs
@@ -1,9 +1,10 @@
 namespace Villainous.Model;
 
 using System;
+using System.ComponentModel.DataAnnotations;
 
 public record SubmitCommandRequest(
-    string Type,
+    [property: Required, MinLength(1)] string Type,
     Guid PlayerId,
     int ClientSeq,
     Guid? TargetPlayerId,


### PR DESCRIPTION
## Summary
- add fixed-window rate limiting for API and SignalR
- sanitize and validate incoming DTOs
- disable rate limiter in test environment and remove obsolete package
- test coverage for validation and rate limits

## Testing
- `dotnet format --no-restore --verify-no-changes -v diag`
- `dotnet test`
- `pnpm -C apps/web test`
- `pnpm -C apps/web lint`
- `pnpm -C apps/web exec tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b2b55ad17883268c678a4fa036d423